### PR TITLE
Change SQL request in howtoget.py

### DIFF
--- a/howtoget.py
+++ b/howtoget.py
@@ -21,7 +21,7 @@ while True:
     target = random.choice(list(targets)) # ummm this is kinda stupid but it works ig...
     if target in base:
         continue
-    c.execute("SELECT ingr1, ingr2 FROM combination WHERE out = ?", [target])
+    c.execute("SELECT ingr1, ingr2 FROM combination WHERE out LIKE ?", [target])
     ingr = c.fetchone()
     if ingr == None:
         print(f"didn't find source of {target}...")


### PR DESCRIPTION
Change comparison in SQL from = to LIKE because this doesn't require correct capitalization of words.

This is due to words like "Harry Potter and the Goblet of Fire" beeing converted to "Harry Potter And The Goblet Of Fire" in line 15, which wouldn't be found by using =